### PR TITLE
[booster] Preserve EGID for privileged processes, and build from master. JB#49488

### DIFF
--- a/rpm/0001-Preserve-process-effective-group-for-privileged-grou.patch
+++ b/rpm/0001-Preserve-process-effective-group-for-privileged-grou.patch
@@ -1,0 +1,18 @@
+From d5db08f9453bf51137c54d8a6fb90727d83ed67d Wed, 15 Apr 2020 15:03:25 +0200
+From: Andrew Branson <andrew.branson@jolla.com>
+Date: Wed, 15 Apr 2020 14:12:17 +0200
+Subject: [PATCH] Preserve process effective group for privileged group support
+
+diff --git a/src/include/euid_common.h b/src/include/euid_common.h
+index d8277ad..0dd1c16 100644
+--- a/src/include/euid_common.h
++++ b/src/include/euid_common.h
+@@ -53,7 +53,7 @@
+ 
+ static inline void EUID_INIT(void) {
+ 	firejail_uid = getuid();
+-	firejail_gid = getgid();
++	firejail_gid = getegid();
+ }
+ 
+ #endif

--- a/rpm/firejail.spec
+++ b/rpm/firejail.spec
@@ -4,6 +4,7 @@ Release: 1
 Summary: Linux namepaces sandbox program
 License: GPLv2+
 Source0: https://github.com/netblue30/firejail/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:  0001-Preserve-process-effective-group-for-privileged-grou.patch
 URL: https://github.com/netblue30/firejail
 
 %description
@@ -19,7 +20,7 @@ Requires: %{name} = %{version}-%{release}
 %{summary}.
 
 %prep
-%setup -q -n %{name}-%{version}/upstream
+%autosetup -p1 -n %{name}-%{version}/upstream
 
 %build
 %configure \


### PR DESCRIPTION


Tracking master for ARM syscalls and xdg-dbus-proxy support