### PR TITLE
[build] Update Firejail to 0.9.62.4. Fixes JB#50747

### DIFF
--- a/rpm/firejail.spec
+++ b/rpm/firejail.spec
@@ -1,5 +1,5 @@
 Name: firejail
-Version: 0.9.62
+Version: 0.9.62.4
 Release: 1
 Summary: Linux namepaces sandbox program
 License: GPLv2+


### PR DESCRIPTION
- CVE-2020-17367 CVE-2020-17368 fixed in 0.9.62.2
- Build related fixes may fix the occasional race failure seen in aarch64