### PR TITLE
[firejail] Do not leave file mounts underneath private-etc. Fixes JB#52473

### DIFF
--- a/rpm/0009-sandbox-Do-not-leave-file-mounts-underneath-private-.patch
+++ b/rpm/0009-sandbox-Do-not-leave-file-mounts-underneath-private-.patch
@@ -1,0 +1,107 @@
+From 89e853daac52a4aea24c7bc8bc7671597a79632c Mon Sep 17 00:00:00 2001
+From: Simo Piiroinen <simo.piiroinen@jolla.com>
+Date: Wed, 16 Dec 2020 11:18:03 +0200
+Subject: [PATCH] sandbox: Do not leave file mounts underneath private-etc
+
+Firejail uses file bind-mounts to filter /etc/passwd and /etc/group
+content. If private-etc is used, these mounts are left underneath
+the /etc directory mount and this seems to be causing problems in
+devices with older kernels: attempts to modify passwd or group
+data fails with EBUSY.
+
+Make it possible to perform fs_private_dir_list() actions in two
+separate phases.
+
+Undo the file mounts in /etc before mounting private-etc content.
+
+Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+---
+ src/firejail/firejail.h |  2 ++
+ src/firejail/fs_etc.c   |  9 ++++++++-
+ src/firejail/sandbox.c  | 25 +++++++++++++++++++++++--
+ 3 files changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/src/firejail/firejail.h b/src/firejail/firejail.h
+index bcfe61c2..f0c6319e 100644
+--- a/src/firejail/firejail.h
++++ b/src/firejail/firejail.h
+@@ -654,6 +654,8 @@ void network_set_run_file(pid_t pid);
+ 
+ // fs_etc.c
+ void fs_machineid(void);
++void fs_private_dir_copy(const char *private_dir, const char *private_run_dir, const char *private_list);
++void fs_private_dir_mount(const char *private_dir, const char *private_run_dir);
+ void fs_private_dir_list(const char *private_dir, const char *private_run_dir, const char *private_list);
+ 
+ // no_sandbox.c
+diff --git a/src/firejail/fs_etc.c b/src/firejail/fs_etc.c
+index 271e4685..908134ef 100644
+--- a/src/firejail/fs_etc.c
++++ b/src/firejail/fs_etc.c
+@@ -138,7 +138,7 @@ static void duplicate(const char *fname, const char *private_dir, const char *pr
+ }
+ 
+ 
+-void fs_private_dir_list(const char *private_dir, const char *private_run_dir, const char *private_list) {
++void fs_private_dir_copy(const char *private_dir, const char *private_run_dir, const char *private_list) {
+ 	assert(private_dir);
+ 	assert(private_run_dir);
+ 	assert(private_list);
+@@ -185,7 +185,9 @@ void fs_private_dir_list(const char *private_dir, const char *private_run_dir, c
+ 		free(dlist);
+ 		fs_logger_print();
+ 	}
++}
+ 
++void fs_private_dir_mount(const char *private_dir, const char *private_run_dir) {
+ 	if (arg_debug)
+ 		printf("Mount-bind %s on top of %s\n", private_run_dir, private_dir);
+ 	if (mount(private_run_dir, private_dir, NULL, MS_BIND|MS_REC, NULL) < 0)
+@@ -199,3 +201,8 @@ void fs_private_dir_list(const char *private_dir, const char *private_run_dir, c
+ 
+ 	fmessage("Private %s installed in %0.2f ms\n", private_dir, timetrace_end());
+ }
++
++void fs_private_dir_list(const char *private_dir, const char *private_run_dir, const char *private_list) {
++	fs_private_dir_copy(private_dir, private_run_dir, private_list);
++	fs_private_dir_mount(private_dir, private_run_dir);
++}
+diff --git a/src/firejail/sandbox.c b/src/firejail/sandbox.c
+index 9116d88b..1bb05a75 100644
+--- a/src/firejail/sandbox.c
++++ b/src/firejail/sandbox.c
+@@ -1053,8 +1053,29 @@ int sandbox(void* sandbox_arg) {
+ 		else if (arg_overlay)
+ 			fwarning("private-etc feature is disabled in overlay\n");
+ 		else {
+-			fs_private_dir_list("/etc", RUN_ETC_DIR, cfg.etc_private_keep);
+-			fs_private_dir_list("/usr/etc", RUN_USR_ETC_DIR, cfg.etc_private_keep); // openSUSE
++			/* Current /etc/passwd and /etc/group files are bind
++			 * mounted filtered versions of originals. Leaving
++			 * them underneath privete-etc mount causes problems
++			 * in devices with older kernels, e.g. attempts to
++			 * update the real /etc/passwd file yield EBUSY.
++			 *
++			 * As we do want to retain filtered /etc content:
++			 * 1. duplicate /etc content to RUN_ETC_DIR
++			 * 2. unmount bind mounts from /etc
++			 * 3. mount RUN_ETC_DIR at /etc
++			 */
++			fs_private_dir_copy("/etc", RUN_ETC_DIR, cfg.etc_private_keep);
++			fs_private_dir_copy("/usr/etc", RUN_USR_ETC_DIR, cfg.etc_private_keep); // openSUSE
++
++			if (umount2("/etc/group", MNT_DETACH) == -1)
++				fprintf(stderr, "/etc/group: unmount: %m\n");
++
++			if (umount2("/etc/passwd", MNT_DETACH) == -1)
++				fprintf(stderr, "/etc/passwd: unmount: %m\n");
++
++			fs_private_dir_mount("/etc", RUN_ETC_DIR);
++			fs_private_dir_mount("/usr/etc", RUN_USR_ETC_DIR);
++
+ 			// create /etc/ld.so.preload file again
+ 			if (need_preload)
+ 				fs_trace_preload();
+-- 
+2.17.1
+

--- a/rpm/firejail.spec
+++ b/rpm/firejail.spec
@@ -12,6 +12,7 @@ Patch5:  0005-Add-missing-linefeeds-in-stderr-logging.patch
 Patch6:  0006-PATCH-Add-mkdir-and-mkfile-command-line-options-for-.patch
 Patch7:  0007-fcopy-Fix-memory-leaks.patch
 Patch8:  0008-Implement-SailfishOS-specific-privileged-data-.patch
+Patch9:  0009-sandbox-Do-not-leave-file-mounts-underneath-private-.patch
 
 URL: https://github.com/netblue30/firejail
 


### PR DESCRIPTION
Having /etc/passwd and /etc/group file mounts underneath private-etc
directory mount causes updating real passwd and group files to fail
in devices with sufficiently old kernels.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>