### PR TITLE
[firejail] Upgrade to 0.9.64.4. Fixes JB#51939

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "upstream"]
 	path = upstream
-	url = https://github.com/netblue30/firejail.git
+	url = https://github.com/sailfishos-mirror/firejail.git

--- a/rpm/0001-Fix-symlinks-that-go-though-proc-self.patch
+++ b/rpm/0001-Fix-symlinks-that-go-though-proc-self.patch
@@ -1,7 +1,10 @@
-From e69a972458b4d520aa70d5134eadade1317041bf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Fri, 9 Oct 2020 12:15:31 +0300
 Subject: [PATCH] Fix symlinks that go though /proc/self
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 When constructing sandbox fs, /etc/mtab which is symlink to
 /proc/self/mounts gets resolved as /proc/PID/mounts. Where
@@ -13,12 +16,13 @@ Use /proc/self/xxx type symlink target if it resolves similarly
 as the /proc/PID/xxx type would at the time of mapping.
 
 Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
  src/fcopy/main.c | 43 ++++++++++++++++++++++++++++++++++++++++++-
  1 file changed, 42 insertions(+), 1 deletion(-)
 
 diff --git a/src/fcopy/main.c b/src/fcopy/main.c
-index 67237b4e..48e5fb48 100644
+index e65501d6..43790605 100644
 --- a/src/fcopy/main.c
 +++ b/src/fcopy/main.c
 @@ -172,6 +172,47 @@ static void mkdir_attr(const char *fname, mode_t mode, uid_t uid, gid_t gid) {
@@ -70,7 +74,7 @@ index 67237b4e..48e5fb48 100644
  void copy_link(const char *target, const char *linkpath, mode_t mode, uid_t uid, gid_t gid) {
  	(void) mode;
 @@ -183,7 +224,7 @@ void copy_link(const char *target, const char *linkpath, mode_t mode, uid_t uid,
- 	if (stat(linkpath, &s) == 0)
+ 	if (lstat(linkpath, &s) == 0)
  	       return;
  
 -	char *rp = realpath(target, NULL);
@@ -79,5 +83,5 @@ index 67237b4e..48e5fb48 100644
  		if (symlink(rp, linkpath) == -1) {
  			free(rp);
 -- 
-2.17.1
+2.29.2
 

--- a/rpm/0002-fcopy-Fix-memory-leaks.patch
+++ b/rpm/0002-fcopy-Fix-memory-leaks.patch
@@ -1,19 +1,23 @@
-From 1130d1f519a99bd296642eeb4a07519e221777a2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Thu, 10 Dec 2020 13:55:25 +0200
 Subject: [PATCH] fcopy: Fix memory leaks
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 These have little consequences as the tool exits anyway,
 but fs_copydir() leaks memory on success path and check()
 on failure path.
 
 Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
  src/fcopy/main.c | 13 ++++++-------
  1 file changed, 6 insertions(+), 7 deletions(-)
 
 diff --git a/src/fcopy/main.c b/src/fcopy/main.c
-index 48e5fb48..5f743297 100644
+index 43790605..6a51d363 100644
 --- a/src/fcopy/main.c
 +++ b/src/fcopy/main.c
 @@ -268,16 +268,14 @@ static int fs_copydir(const char *infname, const struct stat *st, int ftype, str
@@ -64,5 +68,5 @@ index 48e5fb48..5f743297 100644
  	exit(1);
  }
 -- 
-2.17.1
+2.29.2
 

--- a/rpm/0003-sandbox-Do-not-leave-file-mounts-underneath-private-.patch
+++ b/rpm/0003-sandbox-Do-not-leave-file-mounts-underneath-private-.patch
@@ -1,7 +1,10 @@
-From 89e853daac52a4aea24c7bc8bc7671597a79632c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Wed, 16 Dec 2020 11:18:03 +0200
 Subject: [PATCH] sandbox: Do not leave file mounts underneath private-etc
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Firejail uses file bind-mounts to filter /etc/passwd and /etc/group
 content. If private-etc is used, these mounts are left underneath
@@ -15,6 +18,7 @@ separate phases.
 Undo the file mounts in /etc before mounting private-etc content.
 
 Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
  src/firejail/firejail.h |  2 ++
  src/firejail/fs_etc.c   |  9 ++++++++-
@@ -22,10 +26,10 @@ Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
  3 files changed, 33 insertions(+), 3 deletions(-)
 
 diff --git a/src/firejail/firejail.h b/src/firejail/firejail.h
-index bcfe61c2..f0c6319e 100644
+index 9ea3edcd..1b979089 100644
 --- a/src/firejail/firejail.h
 +++ b/src/firejail/firejail.h
-@@ -654,6 +654,8 @@ void network_set_run_file(pid_t pid);
+@@ -647,6 +647,8 @@ void network_set_run_file(pid_t pid);
  
  // fs_etc.c
  void fs_machineid(void);
@@ -67,10 +71,10 @@ index 271e4685..908134ef 100644
 +	fs_private_dir_mount(private_dir, private_run_dir);
 +}
 diff --git a/src/firejail/sandbox.c b/src/firejail/sandbox.c
-index 9116d88b..1bb05a75 100644
+index d811fe45..4f5fe368 100644
 --- a/src/firejail/sandbox.c
 +++ b/src/firejail/sandbox.c
-@@ -1053,8 +1053,29 @@ int sandbox(void* sandbox_arg) {
+@@ -970,8 +970,29 @@ int sandbox(void* sandbox_arg) {
  		else if (arg_overlay)
  			fwarning("private-etc feature is disabled in overlay\n");
  		else {
@@ -78,7 +82,7 @@ index 9116d88b..1bb05a75 100644
 -			fs_private_dir_list("/usr/etc", RUN_USR_ETC_DIR, cfg.etc_private_keep); // openSUSE
 +			/* Current /etc/passwd and /etc/group files are bind
 +			 * mounted filtered versions of originals. Leaving
-+			 * them underneath privete-etc mount causes problems
++			 * them underneath private-etc mount causes problems
 +			 * in devices with older kernels, e.g. attempts to
 +			 * update the real /etc/passwd file yield EBUSY.
 +			 *
@@ -103,5 +107,5 @@ index 9116d88b..1bb05a75 100644
  			if (need_preload)
  				fs_trace_preload();
 -- 
-2.17.1
+2.29.2
 

--- a/rpm/0004-Add-missing-linefeeds-in-stderr-logging.patch
+++ b/rpm/0004-Add-missing-linefeeds-in-stderr-logging.patch
@@ -1,11 +1,15 @@
-From c12ab15258d6e7e0c5e0ff65089f2b7875c6b98b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Thu, 12 Nov 2020 16:04:53 +0200
 Subject: [PATCH] Add missing linefeeds in stderr logging
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Lacking linefeed chars cause messages to get concatenated.
 
 Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
  src/firejail/fs_mkdir.c     | 4 ++--
  src/firejail/main.c         | 2 +-
@@ -35,10 +39,10 @@ index 0e213f2f..db2b388a 100644
  		}
  
 diff --git a/src/firejail/main.c b/src/firejail/main.c
-index 34e23e10..cfd68cf4 100644
+index 0f0086a6..f5fd57ba 100644
 --- a/src/firejail/main.c
 +++ b/src/firejail/main.c
-@@ -298,7 +298,7 @@ static void check_network(Bridge *br) {
+@@ -297,7 +297,7 @@ static void check_network(Bridge *br) {
  	else if (br->ipsandbox) { // for macvlan check network range
  		char *rv = in_netrange(br->ipsandbox, br->ip, br->mask);
  		if (rv) {
@@ -61,5 +65,5 @@ index 85896e52..9751ea19 100644
  		}
  		// send an ARP request and check if there is anybody on this IP address
 -- 
-2.17.1
+2.29.2
 

--- a/rpm/0005-Add-checks-to-fs_private_dir_mount.patch
+++ b/rpm/0005-Add-checks-to-fs_private_dir_mount.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomi=20Lepp=C3=A4nen?= <tomi.leppanen@jolla.com>
+Date: Mon, 22 Feb 2021 09:59:55 +0200
+Subject: [PATCH] Add checks to fs_private_dir_mount
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Check that the directory exists before attempting to mount it.
+
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
+---
+ src/firejail/fs_etc.c | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/src/firejail/fs_etc.c b/src/firejail/fs_etc.c
+index 908134ef..17636b93 100644
+--- a/src/firejail/fs_etc.c
++++ b/src/firejail/fs_etc.c
+@@ -18,6 +18,7 @@
+  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+ #include "firejail.h"
++#include <errno.h>
+ #include <sys/mount.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+@@ -147,7 +148,7 @@ void fs_private_dir_copy(const char *private_dir, const char *private_run_dir, c
+ 	struct stat s;
+ 	if (stat(private_dir, &s) == -1) {
+ 		if (arg_debug)
+-			printf("Cannot find %s\n", private_dir);
++			printf("Cannot find %s: %s\n", private_dir, strerror(errno));
+ 		return;
+ 	}
+ 
+@@ -188,8 +189,20 @@ void fs_private_dir_copy(const char *private_dir, const char *private_run_dir, c
+ }
+ 
+ void fs_private_dir_mount(const char *private_dir, const char *private_run_dir) {
++	assert(private_dir);
++	assert(private_run_dir);
++
+ 	if (arg_debug)
+ 		printf("Mount-bind %s on top of %s\n", private_run_dir, private_dir);
++
++	// nothing to do if directory does not exist
++	struct stat s;
++	if (stat(private_dir, &s) == -1) {
++		if (arg_debug)
++			printf("Cannot find %s: %s\n", private_dir, strerror(errno));
++		return;
++	}
++
+ 	if (mount(private_run_dir, private_dir, NULL, MS_BIND|MS_REC, NULL) < 0)
+ 		errExit("mount bind");
+ 	fs_logger2("mount", private_dir);
+-- 
+2.29.2
+

--- a/rpm/0006-Add-mkdir-and-mkfile-command-line-options-for-fireja.patch
+++ b/rpm/0006-Add-mkdir-and-mkfile-command-line-options-for-fireja.patch
@@ -1,7 +1,10 @@
-From fae2d6400914d4ec0d53d9fc0ef98c37583873b2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Tue, 24 Nov 2020 13:18:51 +0200
 Subject: [PATCH] Add --mkdir and --mkfile command line options for firejail
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Profile files are defined as a means to "pass several command line
 arguments to firejail" but apparently for example mkdir and mkfile
@@ -10,23 +13,24 @@ specified directly from command line.
 
 Add support for -mkdir and --mkfile options so that executing:
   firejail --mkdir=${HOME}/directory/path\
-           --whitelist==${HOME}/directory/path
+           --whitelist=${HOME}/directory/path
 
 behaves similarly as having profile file content:
   mkdir ${HOME}/directory/path
   whitelist ${HOME}/directory/path
 
 Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
  src/firejail/main.c  | 21 ++++++++++++++++++++-
  src/firejail/usage.c |  2 ++
  2 files changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/src/firejail/main.c b/src/firejail/main.c
-index cfd68cf4..d52d53c9 100644
+index f5fd57ba..64964a9d 100644
 --- a/src/firejail/main.c
 +++ b/src/firejail/main.c
-@@ -1568,7 +1568,26 @@ int main(int argc, char **argv, char **envp) {
+@@ -1581,7 +1581,26 @@ int main(int argc, char **argv, char **envp) {
  			profile_add(line);
  		}
  #endif
@@ -68,5 +72,5 @@ index d58bbb40..190339f0 100644
  	"    --writable-run-user - allow access to /run/user/$UID/systemd and\n"
  	"\t/run/user/$UID/gnupg.\n"
 -- 
-2.17.1
+2.29.2
 

--- a/rpm/0007-Add-utility-functions-for-handling-comma-separated-l.patch
+++ b/rpm/0007-Add-utility-functions-for-handling-comma-separated-l.patch
@@ -1,7 +1,10 @@
-From 3565dae1c9ee1bc77a0472880fcb3773943e3d32 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Thu, 5 Nov 2020 18:52:29 +0200
-Subject: [PATCH] Add utility functions for handing comma separated lists
+Subject: [PATCH] Add utility functions for handling comma separated lists
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 A lot of profile options deal with manipulating strings containing
 comma separated list of things, using several strains of similar but
@@ -13,13 +16,14 @@ make higher level logic shorter, cleaner and function in more uniform
 manner.
 
 Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
  src/firejail/firejail.h |   3 +
- src/firejail/profile.c  | 136 ++++++++++++++++++++++++++++++++++++++++
- 2 files changed, 139 insertions(+)
+ src/firejail/profile.c  | 140 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 143 insertions(+)
 
 diff --git a/src/firejail/firejail.h b/src/firejail/firejail.h
-index 2bb8dd35..b8bdae88 100644
+index 1b979089..bbb555df 100644
 --- a/src/firejail/firejail.h
 +++ b/src/firejail/firejail.h
 @@ -449,6 +449,9 @@ int profile_check_line(char *ptr, int lineno, const char *fname);
@@ -33,10 +37,10 @@ index 2bb8dd35..b8bdae88 100644
  // list.c
  void list(void);
 diff --git a/src/firejail/profile.c b/src/firejail/profile.c
-index 8c29fe81..9bc08b80 100644
+index 1ee8cdfc..456fc009 100644
 --- a/src/firejail/profile.c
 +++ b/src/firejail/profile.c
-@@ -1748,3 +1748,139 @@ void profile_read(const char *fname) {
+@@ -1774,3 +1774,143 @@ void profile_read(const char *fname) {
  	}
  	fclose(fp);
  }
@@ -68,6 +72,8 @@ index 8c29fe81..9bc08b80 100644
 +
 +char *profile_list_compress(char *list)
 +{
++	size_t i;
++
 +	/* Comma separated list is processed so that:
 +	 * "item"  -> adds item to list
 +	 * "-item" -> removes item from list
@@ -87,7 +93,7 @@ index 8c29fe81..9bc08b80 100644
 +
 +	/* Count items: comma count + 1 */
 +	size_t count = 1;
-+	for (size_t i=0; list[i]; ++i) {
++	for (i = 0; list[i]; ++i) {
 +		if (list[i] == ',')
 +			++count;
 +	}
@@ -96,7 +102,7 @@ index 8c29fe81..9bc08b80 100644
 +	char *in[count];
 +	count = 0;
 +	in[count++] = list;
-+	for (size_t i=0; list[i]; ++i) {
++	for (i = 0; list[i]; ++i) {
 +		if (list[i] != ',')
 +			continue;
 +		list[i] = 0;
@@ -104,16 +110,18 @@ index 8c29fe81..9bc08b80 100644
 +	}
 +
 +	/* Filter array: add, remove, reset, filter out duplicates */
-+	for (size_t i = 0; i < count; ++i) {
++	for (i = 0; i < count; ++i) {
 +		char *item = in[i];
++		assert(item);
 +
++		size_t k;
 +		switch (*item) {
 +		case '-':
 +			++item;
 +			/* Do not include this item */
 +			in[i] = 0;
 +			/* Remove if already included */
-+			for (size_t k = 0; k < i; ++k) {
++			for (k = 0; k < i; ++k) {
 +				if (in[k] && !strcmp(in[k], item)) {
 +					in[k] = 0;
 +					break;
@@ -131,7 +139,7 @@ index 8c29fe81..9bc08b80 100644
 +				break;
 +			}
 +			/* Include item unless it is already included */
-+			for (size_t k = 0; k < i; ++k) {
++			for (k = 0; k < i; ++k) {
 +				if (in[k] && !strcmp(in[k], item)) {
 +					in[i] = 0;
 +					break;
@@ -144,7 +152,7 @@ index 8c29fe81..9bc08b80 100644
 +			if (!*item)
 +				in[i] = 0;
 +			/* Remove all allready included items */
-+			for (size_t k = 0; k < i; ++k)
++			for (k = 0; k < i; ++k)
 +				in[k] = 0;
 +			break;
 +		}
@@ -155,7 +163,7 @@ index 8c29fe81..9bc08b80 100644
 +	 * than what it used to be.
 +	 */
 +	char *pos = list;
-+	for (size_t i = 0; i < count; ++i) {
++	for (i = 0; i < count; ++i) {
 +		char *item = in[i];
 +		if (!item)
 +			continue;
@@ -177,5 +185,5 @@ index 8c29fe81..9bc08b80 100644
 +	*list = profile_list_compress(tmp);
 +}
 -- 
-2.17.1
+2.29.2
 

--- a/rpm/0008-Allow-changing-protocol-list-after-initial-set.patch
+++ b/rpm/0008-Allow-changing-protocol-list-after-initial-set.patch
@@ -1,7 +1,10 @@
-From 5fa8913298967857f49a30cee8e40b516b6aab21 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Fri, 6 Nov 2020 10:13:35 +0200
 Subject: [PATCH] Allow changing "protocol" list after initial set
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Firejail uses set-once logic for "protocol" list. This makes it
 impossible to accumulate list of allowed protocols from multiple
@@ -12,21 +15,22 @@ implicitly means protocols can be added/removed via any number of
 command line options / profile configuration files.
 
 Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
  src/firejail/main.c    | 13 ++++---------
  src/firejail/profile.c | 13 ++++---------
  2 files changed, 8 insertions(+), 18 deletions(-)
 
 diff --git a/src/firejail/main.c b/src/firejail/main.c
-index 5cc2d412..34e23e10 100644
+index 64964a9d..7510a042 100644
 --- a/src/firejail/main.c
 +++ b/src/firejail/main.c
-@@ -1269,15 +1269,10 @@ int main(int argc, char **argv, char **envp) {
+@@ -1277,15 +1277,10 @@ int main(int argc, char **argv, char **envp) {
  #endif
  		else if (strncmp(argv[i], "--protocol=", 11) == 0) {
  			if (checkcfg(CFG_SECCOMP)) {
 -				if (cfg.protocol) {
--					fwarning("two protocol lists are present, \"%s\" will be installed\n", cfg.protocol);
+-					fwarning("more than one protocol list is present, \"%s\" will be installed\n", cfg.protocol);
 -				}
 -				else {
 -					// store list
@@ -42,15 +46,15 @@ index 5cc2d412..34e23e10 100644
  			else
  				exit_err_feature("seccomp");
 diff --git a/src/firejail/profile.c b/src/firejail/profile.c
-index 9bc08b80..d623f417 100644
+index 456fc009..86154a1b 100644
 --- a/src/firejail/profile.c
 +++ b/src/firejail/profile.c
-@@ -892,15 +892,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
+@@ -911,15 +911,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
  
  	if (strncmp(ptr, "protocol ", 9) == 0) {
  		if (checkcfg(CFG_SECCOMP)) {
 -			if (cfg.protocol) {
--				fwarning("two protocol lists are present, \"%s\" will be installed\n", cfg.protocol);
+-				fwarning("more than one protocol list is present, \"%s\" will be installed\n", cfg.protocol);
 -				return 0;
 -			}
 -
@@ -66,5 +70,5 @@ index 9bc08b80..d623f417 100644
  		else
  			warning_feature_disabled("seccomp");
 -- 
-2.17.1
+2.29.2
 

--- a/rpm/0009-Preserve-process-effective-group-for-privileged-grou.patch
+++ b/rpm/0009-Preserve-process-effective-group-for-privileged-grou.patch
@@ -1,13 +1,17 @@
-From d5db08f9453bf51137c54d8a6fb90727d83ed67d Wed, 15 Apr 2020 15:03:25 +0200
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Branson <andrew.branson@jolla.com>
 Date: Wed, 15 Apr 2020 14:12:17 +0200
 Subject: [PATCH] Preserve process effective group for privileged group support
 
+---
+ src/include/euid_common.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/src/include/euid_common.h b/src/include/euid_common.h
-index d8277ad..0dd1c16 100644
+index d8277ade..0dd1c162 100644
 --- a/src/include/euid_common.h
 +++ b/src/include/euid_common.h
-@@ -53,7 +53,7 @@
+@@ -53,7 +53,7 @@ static inline void EUID_PRINT(void) {
  
  static inline void EUID_INIT(void) {
  	firejail_uid = getuid();
@@ -16,3 +20,6 @@ index d8277ad..0dd1c16 100644
  }
  
  #endif
+-- 
+2.29.2
+

--- a/rpm/0010-Implement-Sailfish-OS-specific-privileged-data-optio.patch
+++ b/rpm/0010-Implement-Sailfish-OS-specific-privileged-data-optio.patch
@@ -1,4 +1,4 @@
-From e2bd14f8a6a6d8eab07b84c36c32b99cd5c8d28a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simo Piiroinen <simo.piiroinen@jolla.com>
 Date: Thu, 26 Nov 2020 19:29:29 +0200
 Subject: [PATCH] Implement Sailfish OS specific privileged-data option
@@ -31,18 +31,18 @@ get_user_id() function.
 Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
 ---
  src/firejail/firejail.h   |   5 +-
- src/firejail/macros.c     |   9 ++++
- src/firejail/main.c       | 107 ++++++++++++++++++++++----------------
+ src/firejail/macros.c     |   9 +++
+ src/firejail/main.c       | 112 +++++++++++++++++++++-----------------
  src/firejail/profile.c    |  31 +++++++++++
- src/firejail/sandbox.c    |  76 +++++++++++++++++++++++++++
+ src/firejail/sandbox.c    |  76 ++++++++++++++++++++++++++
  src/firejail/usage.c      |   1 +
  src/firejail/util.c       |  23 +++++---
- src/include/euid_common.h |  86 +++++++++++++++++++++++-------
+ src/include/euid_common.h |  86 ++++++++++++++++++++++-------
  src/include/rundefs.h     |   1 +
- 9 files changed, 266 insertions(+), 73 deletions(-)
+ 9 files changed, 266 insertions(+), 78 deletions(-)
 
 diff --git a/src/firejail/firejail.h b/src/firejail/firejail.h
-index b8bdae88..bcfe61c2 100644
+index bbb555df..e4eebe62 100644
 --- a/src/firejail/firejail.h
 +++ b/src/firejail/firejail.h
 @@ -156,6 +156,7 @@ typedef struct config_t {
@@ -61,9 +61,9 @@ index b8bdae88..bcfe61c2 100644
  char *profile_list_normalize(char *list);
  char *profile_list_compress(char *list);
  void profile_list_augment(char **list, const char *items);
-@@ -518,7 +520,8 @@ void wait_for_other(int fd);
+@@ -517,7 +519,8 @@ void update_map(char *mapping, char *map_file);
+ void wait_for_other(int fd);
  void notify_other(int fd);
- const char *gnu_basename(const char *path);
  uid_t pid_get_uid(pid_t pid);
 -uid_t get_group_id(const char *group);
 +gid_t get_group_id(const char *group);
@@ -99,7 +99,7 @@ index 2623d794..8c3635b0 100644
  		int id = macro_id(fname);
  		if (id != -1)
 diff --git a/src/firejail/main.c b/src/firejail/main.c
-index d52d53c9..150ee96f 100644
+index 7510a042..4a367d7e 100644
 --- a/src/firejail/main.c
 +++ b/src/firejail/main.c
 @@ -53,8 +53,7 @@ int __clone2(int (*fn)(void *),
@@ -112,7 +112,7 @@ index d52d53c9..150ee96f 100644
  
  #define STACK_SIZE (1024 * 1024)
  #define STACK_ALIGNMENT 16
-@@ -981,7 +980,7 @@ int main(int argc, char **argv, char **envp) {
+@@ -982,7 +981,7 @@ int main(int argc, char **argv, char **envp) {
  	fix_std_streams();
  
  	// drop permissions by default and rise them when required
@@ -121,7 +121,7 @@ index d52d53c9..150ee96f 100644
  	EUID_USER();
  
  	// argument count should be larger than 0
-@@ -1957,6 +1956,12 @@ int main(int argc, char **argv, char **envp) {
+@@ -1965,6 +1964,12 @@ int main(int argc, char **argv, char **envp) {
  				cfg.opt_private_keep = argv[i] + 14;
  			arg_private_opt = 1;
  		}
@@ -134,7 +134,7 @@ index d52d53c9..150ee96f 100644
  		else if (strncmp(argv[i], "--private-srv=", 14) == 0) {
  			// extract private srv list
  			if (*(argv[i] + 14) == '\0') {
-@@ -2994,64 +2999,74 @@ int main(int argc, char **argv, char **envp) {
+@@ -3011,71 +3016,76 @@ int main(int argc, char **argv, char **envp) {
  
   	if (arg_noroot) {
  	 	// update the UID and GID maps in the new child user namespace
@@ -142,10 +142,6 @@ index d52d53c9..150ee96f 100644
 -	 	char *map_path;
 -	 	if (asprintf(&map_path, "/proc/%d/uid_map", child) == -1)
 -	 		errExit("asprintf");
- 
--	 	char *map;
--	 	uid_t uid = getuid();
--	 	if (asprintf(&map, "%d %d 1", uid, uid) == -1)
 +		/* NB: In Linux 4.14 and earlier, id mapping data can have at
 +		 *     maximum 5 lines - see user_namespaces (7) for details. */
 +		const int id_max = 5;
@@ -170,7 +166,10 @@ index d52d53c9..150ee96f 100644
 +				}
 +			}
 +		}
-+
+ 
+-	 	char *map;
+-	 	uid_t uid = getuid();
+-	 	if (asprintf(&map, "%d %d 1", uid, uid) == -1)
 +		auto char *id_map(void) {
 +			char *ptr = map_data;
 +			for (int i = 0; i < id_cnt; ++i) {
@@ -208,14 +207,22 @@ index d52d53c9..150ee96f 100644
 -	 	gid_t gid = getgid();
 -	 	sprintf(ptr, "%d %d 1\n", gid, gid);
 -	 	ptr += strlen(ptr);
--
+ 
 +		id_add(0);
 +		id_add(euid_data.gid);
 +		id_add(euid_data.primary_gid);
 +		id_add(euid_data.privileged_gid);
  	 	if (!arg_nogroups) {
+ 		 	//  add firejail group
+-		 	gid_t g = get_group_id("firejail");
+-		 	if (g) {
+-		 		sprintf(ptr, "%d %d 1\n", g, g);
+-		 		ptr += strlen(ptr);
+-		 	}
+-
++			id_add(get_group_id("firejail"));
  		 	//  add tty group
--		 	gid_t g = get_group_id("tty");
+-		 	g = get_group_id("tty");
 -		 	if (g) {
 -		 		sprintf(ptr, "%d %d 1\n", g, g);
 -		 		ptr += strlen(ptr);
@@ -253,10 +260,10 @@ index d52d53c9..150ee96f 100644
  	 	free(map_path);
   	}
 diff --git a/src/firejail/profile.c b/src/firejail/profile.c
-index d623f417..aaf185ae 100644
+index 86154a1b..c57d8d26 100644
 --- a/src/firejail/profile.c
 +++ b/src/firejail/profile.c
-@@ -1269,6 +1269,15 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
+@@ -1289,6 +1289,15 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
  		return 0;
  	}
  
@@ -272,7 +279,7 @@ index d623f417..aaf185ae 100644
  	// private /srv list of files and directories
  	if (strncmp(ptr, "private-srv ", 12) == 0) {
  		if (cfg.srv_private_keep) {
-@@ -1744,6 +1753,28 @@ void profile_read(const char *fname) {
+@@ -1770,6 +1779,28 @@ void profile_read(const char *fname) {
  	fclose(fp);
  }
  
@@ -302,10 +309,10 @@ index d623f417..aaf185ae 100644
  {
  	/* Remove redundant commas.
 diff --git a/src/firejail/sandbox.c b/src/firejail/sandbox.c
-index ff6be986..9116d88b 100644
+index 4f5fe368..834882ad 100644
 --- a/src/firejail/sandbox.c
 +++ b/src/firejail/sandbox.c
-@@ -868,6 +868,82 @@ int sandbox(void* sandbox_arg) {
+@@ -862,6 +862,82 @@ int sandbox(void* sandbox_arg) {
  	if (arg_private_dev)
  		fs_private_dev();
  
@@ -401,10 +408,10 @@ index 190339f0..6974e5fa 100644
  	"    --profile.print=name|pid - print the name of profile file.\n"
  	"    --profile-path=directory - use this directory to look for profile files.\n"
 diff --git a/src/firejail/util.c b/src/firejail/util.c
-index 02befdc1..01e588ad 100644
+index 911c8bd9..c9d9285b 100644
 --- a/src/firejail/util.c
 +++ b/src/firejail/util.c
-@@ -84,7 +84,7 @@ static void clean_supplementary_groups(gid_t gid) {
+@@ -90,7 +90,7 @@ static void clean_supplementary_groups(gid_t gid) {
  	int i = 0;
  	while (allowed[i]) {
  		gid_t g = get_group_id(allowed[i]);
@@ -413,7 +420,7 @@ index 02befdc1..01e588ad 100644
  			int j;
  			for (j = 0; j < ngroups; j++) {
  				if (g == groups[j]) {
-@@ -140,9 +140,9 @@ void drop_privs(int nogroups) {
+@@ -146,9 +146,9 @@ void drop_privs(int nogroups) {
  		clean_supplementary_groups(gid);
  
  	// set uid/gid
@@ -425,7 +432,7 @@ index 02befdc1..01e588ad 100644
  		errExit("setresuid");
  }
  
-@@ -736,6 +736,9 @@ void update_map(char *mapping, char *map_file) {
+@@ -733,6 +733,9 @@ void update_map(char *mapping, char *map_file) {
  		if (mapping[j] == ',')
  			mapping[j] = '\n';
  
@@ -435,7 +442,7 @@ index 02befdc1..01e588ad 100644
  	fd = open(map_file, O_RDWR);
  	if (fd == -1) {
  		fprintf(stderr, "Error: cannot open %s: %s\n", map_file, strerror(errno));
-@@ -875,16 +878,22 @@ uid_t pid_get_uid(pid_t pid) {
+@@ -858,16 +861,22 @@ uid_t pid_get_uid(pid_t pid) {
  
  
  
@@ -571,7 +578,7 @@ index 0dd1c162..f151aa94 100644
  
  #endif
 diff --git a/src/include/rundefs.h b/src/include/rundefs.h
-index 4da2db74..2a4e518e 100644
+index 21aad66f..595c245a 100644
 --- a/src/include/rundefs.h
 +++ b/src/include/rundefs.h
 @@ -45,6 +45,7 @@
@@ -583,5 +590,5 @@ index 4da2db74..2a4e518e 100644
  #define RUN_BIN_DIR			RUN_MNT_DIR "/bin"
  #define RUN_PULSE_DIR			RUN_MNT_DIR "/pulse"
 -- 
-2.17.1
+2.29.2
 

--- a/rpm/firejail.spec
+++ b/rpm/firejail.spec
@@ -1,20 +1,23 @@
 Name: firejail
-Version: 0.9.63
+Version: 0.9.64.4
 Release: 1
 Summary: Linux namepaces sandbox program
 License: GPLv2+
 Source0: %{name}-%{version}.tar.bz2
-Patch1:  0001-Preserve-process-effective-group-for-privileged-grou.patch
-Patch2:  0002-Fix-symlinks-that-go-though-proc-self.patch
-Patch3:  0003-Add-utility-functions-for-handing-comma-separa.patch
-Patch4:  0004-Allow-changing-protocol-list-after-initial-set.patch
-Patch5:  0005-Add-missing-linefeeds-in-stderr-logging.patch
-Patch6:  0006-PATCH-Add-mkdir-and-mkfile-command-line-options-for-.patch
-Patch7:  0007-fcopy-Fix-memory-leaks.patch
-Patch8:  0008-Implement-SailfishOS-specific-privileged-data-.patch
-Patch9:  0009-sandbox-Do-not-leave-file-mounts-underneath-private-.patch
+# Upstreamed and will be in a future version
+Patch1:  0001-Fix-symlinks-that-go-though-proc-self.patch
+Patch2:  0002-fcopy-Fix-memory-leaks.patch
+Patch3:  0003-sandbox-Do-not-leave-file-mounts-underneath-private-.patch
+Patch4:  0004-Add-missing-linefeeds-in-stderr-logging.patch
+Patch5:  0005-Add-checks-to-fs_private_dir_mount.patch
+Patch6:  0006-Add-mkdir-and-mkfile-command-line-options-for-fireja.patch
+Patch7:  0007-Add-utility-functions-for-handling-comma-separated-l.patch
+Patch8:  0008-Allow-changing-protocol-list-after-initial-set.patch
+# Sailfish OS patches
+Patch9:  0009-Preserve-process-effective-group-for-privileged-grou.patch
+Patch10: 0010-Implement-Sailfish-OS-specific-privileged-data-optio.patch
 
-URL: https://github.com/netblue30/firejail
+URL: https://github.com/sailfishos/firejail
 
 %description
 Firejail is a SUID sandbox program that reduces the risk of security


### PR DESCRIPTION
Update upstream to 0.9.64.4 tag and rebase our patches. I used
upstreamed versions of the patches we have already sent to firejail
master. I put the Sailfish OS specific patches on top.