### PR TITLE
[firejail] Allow mkdir for /home directory. JB#54619 OMP#OS-7158

### DIFF
--- a/rpm/0005-Allow-mkdir-for-root-home.patch
+++ b/rpm/0005-Allow-mkdir-for-root-home.patch
@@ -1,0 +1,26 @@
+From a6d3f46e989ad5a71b3d02ff0165702292ebde5d Mon Sep 17 00:00:00 2001
+From: Dmitry <d.okoshkin@omp.ru>
+Date: Mon, 30 Aug 2021 12:48:33 +0300
+Subject: [PATCH] Allow mkdir for root /home
+
+---
+ src/firejail/fs_mkdir.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/firejail/fs_mkdir.c b/src/firejail/fs_mkdir.c
+index 4983db0a..659e4040 100644
+--- a/src/firejail/fs_mkdir.c
++++ b/src/firejail/fs_mkdir.c
+@@ -34,7 +34,8 @@ static void check(const char *fname) {
+ 
+ 	if (strncmp(fname, cfg.homedir, strlen(cfg.homedir)) != 0 &&
+ 	    strncmp(fname, "/tmp", 4) != 0 &&
+-	    strncmp(fname, runuser, strlen(runuser)) != 0) {
++	    strncmp(fname, runuser, strlen(runuser)) != 0 &&
++	    strncmp(fname, "/home", 5) != 0) {
+ 		fprintf(stderr, "Error: only files or directories in user home, /tmp, or /run/user/<UID> are supported by mkdir\n");
+ 		exit(1);
+ 	}
+-- 
+2.31.1.windows.1
+

--- a/rpm/firejail.spec
+++ b/rpm/firejail.spec
@@ -9,6 +9,7 @@ Patch1: 0001-Preserve-process-effective-group-for-privileged-grou.patch
 Patch2: 0002-Implement-Sailfish-OS-specific-privileged-data-optio.patch
 Patch3: 0003-Add-profile-files-to-a-list-when-processing-argument.patch
 Patch4: 0004-Implement-template-addition-for-replacing-keys-in-pr.patch
+Patch4: 0005-Allow-mkdir-for-root-home.patch
 
 URL: https://github.com/sailfishos/firejail
 


### PR DESCRIPTION
Contributes to https://github.com/sailfishos/sailjail-permissions/pull/85.
Some applications like an antivirus and etc want to get access to some shared directory between all users to store big blobs of data in it, /home/.shared is good one.
Permission SharedStorage will make directory inside by /OrganizationName/ApplicationName.