### PR TITLE
[firejail] Retain symlink on /etc/localtime.

### DIFF
--- a/rpm/0011-Revert-new-version-for-NixOS-4887.patch
+++ b/rpm/0011-Revert-new-version-for-NixOS-4887.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Damien Caliste <dcaliste@free.fr>
+Date: Thu, 2 May 2024 10:48:54 +0200
+Subject: [PATCH] Revert "new version for NixOS 4887"
+
+This reverts commit 8c33968747016a8e473719db19f723f310a3a5a3.
+---
+ src/firejail/fs_etc.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/src/firejail/fs_etc.c b/src/firejail/fs_etc.c
+index aa4d76431..3590436d9 100644
+--- a/src/firejail/fs_etc.c
++++ b/src/firejail/fs_etc.c
+@@ -168,14 +168,7 @@ static void duplicate(const char *fname, const char *private_dir, const char *pr
+ 		errExit("asprintf");
+ 
+ 	build_dirs(src, dst, strlen(private_dir), strlen(private_run_dir));
+-
+-	// follow links! this will make a copy of the file or directory pointed by the symlink
+-	// this will solve problems such as NixOS #4887
+-	// don't follow links to dynamic directories such as /proc
+-	if (strcmp(src, "/etc/mtab") == 0)
+-		sbox_run(SBOX_ROOT | SBOX_SECCOMP, 3, PATH_FCOPY, src, dst);
+-	else
+-		sbox_run(SBOX_ROOT | SBOX_SECCOMP, 4, PATH_FCOPY, "--follow-link", src, dst);
++	sbox_run(SBOX_ROOT | SBOX_SECCOMP, 3, PATH_FCOPY, src, dst);
+ 
+ 	free(dst);
+ 	fs_logger2("clone", src);
+-- 
+2.25.1
+

--- a/rpm/firejail.spec
+++ b/rpm/firejail.spec
@@ -15,6 +15,7 @@ Patch7: 0007-Revert-deprecating-shell-3-5196.patch
 Patch8: 0008-refactor-make-rundir-lock-variables-global.patch
 Patch9: 0009-modif-improve-flock-handling.patch
 Patch10: 0010-modif-populate-run-firejail-while-holding-flock.patch
+Patch11: 0011-Revert-new-version-for-NixOS-4887.patch
 
 URL: https://github.com/sailfishos/firejail
 


### PR DESCRIPTION
@pvuorela, this solves the problem of the localtime not being updated inside the jail on timezone change.

I'm wondering about the validity of commit 8c33968747 which introduces a copy for every file under /etc (except mtab), because on NixOS, /etc/fonts is a double symlink. Maybe our patch 0005 is already a better solution and 8c33968747 may be reverted instead of creating exceptions for every symlink we need to keep as a symlink.

At least, this new patch solves the local problem of timezone update. Before the patch, running jolla-calendar with `sailjail -d` has an entry like:
```
Copying /etc/localtime to private /etc                                             
sbox run: /run/firejail/lib/fcopy --follow-link /etc/localtime /run/firejail/mnt/etc
```

while after the patch, the `--follow-link` option is not present anymore and the localtime file inside the jail reflect the content of the actual target on the host.